### PR TITLE
Default users caddy domain to 'localhost' if not specified

### DIFF
--- a/services/users/first-boot.sh
+++ b/services/users/first-boot.sh
@@ -9,7 +9,7 @@
 } > ./app.env
 
 {
-  echo "DOMAIN=$DOMAIN"
+  echo "DOMAIN=${DOMAIN:-localhost}"
   echo "TLS_INTERNAL="
   echo "IP=$(dig @resolver4.opendns.com myip.opendns.com +short)"
 } > ./caddy.env


### PR DESCRIPTION
Fixes #625